### PR TITLE
Add max_turn arg in tester

### DIFF
--- a/ollama_benchmark/judge/main.py
+++ b/ollama_benchmark/judge/main.py
@@ -241,6 +241,7 @@ def main(args):
         prewarm=args.prewarm,
         max_workers=1,
         question=args.question,
+        max_turns=args.max_turns,
         quick_judge=args.quick_judge,
         judge_model=args.judge_model,
         judge_system_prompt=args.judge_system_prompt,

--- a/ollama_benchmark/speed/main.py
+++ b/ollama_benchmark/speed/main.py
@@ -92,6 +92,7 @@ def main(args):
         pull=args.pull,
         prewarm=args.prewarm,
         max_workers=args.max_workers,
+        max_turns=args.max_turns,
         questions=args.questions,
         monitoring_enabled=args.monitoring_enabled,
         tokenizer_model=args.tokenizer_model,


### PR DESCRIPTION
`ollama-benchmark speed --question 81 --model llama3 --max-workers 1 --max_turns 2`

I set max_turns 2 in command, but the ollama-benchmark ran with only one prompt and then stopped after executing. I found out that the max_turns argument doesn't affect the Tester. After making the correction, I confirmed that it now asks the number of questions specified in the setting.